### PR TITLE
Prevent crash and fail promise if the file is not found

### DIFF
--- a/android/src/main/java/com/radweb/cropimage/RNCropImageModule.java
+++ b/android/src/main/java/com/radweb/cropimage/RNCropImageModule.java
@@ -38,6 +38,12 @@ public class RNCropImageModule extends ReactContextBaseJavaModule {
 	public void crop(String path, ReadableMap options, Promise promise) {
 		BitmapFactory factory = new BitmapFactory();
 		Bitmap image = factory.decodeFile(path);
+
+		if (image == null) {
+			promise.reject("Failed to load", "Failed to load image from path [" + path + "]", new Error("Failed to load image from path [" + path + "]"));
+			return;
+		}
+
 		Bitmap cropped = Bitmap.createBitmap(
 				image,
 				options.getInt("left"),


### PR DESCRIPTION
If the image it trying to crop is not found then it would throw a native level exception that's not being caught. If the image it null, fail the promise and return a relevant error message.